### PR TITLE
Fix types

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -11,9 +11,9 @@ export type Connection<U...> = {
 
 export type Signal<T...> = {
 	RBXScriptConnection: RBXScriptConnection?,
-	Connect: <U...>(self: Signal<T...>, fn: (...unknown) -> (), U...) -> Connection<U...>,
+	Connect: <U...>(self: Signal<T...>, fn: (T...) -> (), U...) -> Connection<U...>,
 
-	Once: <U...>(self: Signal<T...>, fn: (...unknown) -> (), U...) -> Connection<U...>,
+	Once: <U...>(self: Signal<T...>, fn: (T...) -> (), U...) -> Connection<U...>,
 	Wait: (self: Signal<T...>) -> T...,
 	Fire: (self: Signal<T...>, T...) -> (),
 	DisconnectAll: (self: Signal<T...>) -> (),
@@ -94,7 +94,7 @@ local rbxConnect, rbxDisconnect do
 	end
 end
 
-local function connect<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: U...): Connection<U...>
+local function connect<T..., U...>(self: Signal<T...>, fn: (T...) -> (), ...: U...): Connection<U...>
 	local head = self._head
 	local cn = setmetatable({
 		Connected = true,
@@ -113,7 +113,7 @@ local function connect<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: 
 	return cn
 end
 
-local function once<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: U...)
+local function once<T..., U...>(self: Signal<T...>, fn: (T...) -> (), ...: U...)
 	local cn
 	cn = connect(self, function(...)
 		disconnect(cn)

--- a/src/init.lua
+++ b/src/init.lua
@@ -11,9 +11,9 @@ export type Connection<U...> = {
 
 export type Signal<T...> = {
 	RBXScriptConnection: RBXScriptConnection?,
-	Connect: <U...>(self: Signal<T...>, fn: (T...) -> (), U...) -> Connection<U...>,
+	Connect: <U...>(self: Signal<T...>, fn: (...unknown) -> (), U...) -> Connection<U...>,
 
-	Once: <U...>(self: Signal<T...>, fn: (T...) -> (), U...) -> Connection<U...>,
+	Once: <U...>(self: Signal<T...>, fn: (...unknown) -> (), U...) -> Connection<U...>,
 	Wait: (self: Signal<T...>) -> T...,
 	Fire: (self: Signal<T...>, T...) -> (),
 	DisconnectAll: (self: Signal<T...>) -> (),
@@ -94,7 +94,7 @@ local rbxConnect, rbxDisconnect do
 	end
 end
 
-local function connect<T..., U...>(self: Signal<T...>, fn: (T...) -> (), ...: U...): Connection<U...>
+local function connect<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: U...): Connection<U...>
 	local head = self._head
 	local cn = setmetatable({
 		Connected = true,
@@ -113,7 +113,7 @@ local function connect<T..., U...>(self: Signal<T...>, fn: (T...) -> (), ...: U.
 	return cn
 end
 
-local function once<T..., U...>(self: Signal<T...>, fn: (T...) -> (), ...: U...)
+local function once<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: U...)
 	local cn
 	cn = connect(self, function(...)
 		disconnect(cn)

--- a/src/init.lua
+++ b/src/init.lua
@@ -11,8 +11,8 @@ export type Connection<U...> = {
 
 export type Signal<T...> = {
 	RBXScriptConnection: RBXScriptConnection?,
+	
 	Connect: <U...>(self: Signal<T...>, fn: (...any) -> (), U...) -> Connection<U...>,
-
 	Once: <U...>(self: Signal<T...>, fn: (...any) -> (), U...) -> Connection<U...>,
 	Wait: (self: Signal<T...>) -> T...,
 	Fire: (self: Signal<T...>, T...) -> (),

--- a/src/init.lua
+++ b/src/init.lua
@@ -11,9 +11,9 @@ export type Connection<U...> = {
 
 export type Signal<T...> = {
 	RBXScriptConnection: RBXScriptConnection?,
-	Connect: <U...>(self: Signal<T...>, fn: (...unknown) -> (), U...) -> Connection<U...>,
+	Connect: <U...>(self: Signal<T...>, fn: (...any) -> (), U...) -> Connection<U...>,
 
-	Once: <U...>(self: Signal<T...>, fn: (...unknown) -> (), U...) -> Connection<U...>,
+	Once: <U...>(self: Signal<T...>, fn: (...any) -> (), U...) -> Connection<U...>,
 	Wait: (self: Signal<T...>) -> T...,
 	Fire: (self: Signal<T...>, T...) -> (),
 	DisconnectAll: (self: Signal<T...>) -> (),

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-oriented-house/lemonsignal"
-version = "1.8.0"
+version = "1.8.1"
 registry = "https://github.com/UpliftGames/wally-index"
 licence = "MIT"
 authors = ["Aspecky", "Sona"]


### PR DESCRIPTION
This pull request fixes the issue where previously, in strict mode, this code would type error since `arg1` and `arg2` are typed as `unknown`.
```lua
--!strict

local signal: Signal.Signal<number, number> = Signal.new()

signal:Connect(function(arg1, arg2)
    print(arg1 + arg2)
end)
```