### PR TITLE
Fixed bug where variadc arguments are ignored if the first argument is false or nil.

### DIFF
--- a/src/LemonSignal.lua
+++ b/src/LemonSignal.lua
@@ -94,11 +94,12 @@ end
 
 local function connect<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: U...): Connection<U...>
 	local head = self._head
+	local packed_args = { ... }
 	local cn = setmetatable({
 		Connected = true,
 		_signal = self,
 		_fn = fn,
-		_varargs = if not ... then false else { ... },
+		_varargs = if #packed_args == 0 then false else packed_args,
 		_next = head,
 		_prev = false,
 	}, Connection)

--- a/src/LemonSignal.lua
+++ b/src/LemonSignal.lua
@@ -94,12 +94,12 @@ end
 
 local function connect<T..., U...>(self: Signal<T...>, fn: (...any) -> (), ...: U...): Connection<U...>
 	local head = self._head
-	local packed_args = { ... }
+	local varargs = { ... }
 	local cn = setmetatable({
 		Connected = true,
 		_signal = self,
 		_fn = fn,
-		_varargs = if #packed_args == 0 then false else packed_args,
+		_varargs = if #varargs == 0 then false else varargs,
 		_next = head,
 		_prev = false,
 	}, Connection)


### PR DESCRIPTION
fixed "connect()" ignoring variadic args if first argument is false or nil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of function arguments for more consistent and explicit processing. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->